### PR TITLE
Add move option to clamscan command

### DIFF
--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest
 
-RUN apk add --no-cache clamav rsyslog wget clamav-libunrar findutils
+RUN apk add --no-cache bash clamav rsyslog wget clamav-libunrar findutils
 
 ENV CLAMSCAN_LOGPATH="/var/log/clamav.log"
-COPY start.sh /start.sh
+COPY start /start
 
-ENTRYPOINT ["/start.sh"]
+ENTRYPOINT ["/start"]

--- a/clamav/start
+++ b/clamav/start
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+[ -f /var/lib/clamav/main.cvd ] || freshclam
+find "$@" -print0 | xargs -r -0 clamscan --log="${CLAMSCAN_LOGPATH}" $([[ -z "${CLAMSCAN_MOVEPATH-}" ]] || printf -- "--move=%s" "${CLAMSCAN_MOVEPATH-}")

--- a/clamav/start.sh
+++ b/clamav/start.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-[ -f /var/lib/clamav/main.cvd ] || freshclam
-find "$@" -print0 | xargs -0 clamscan --log="${CLAMSCAN_LOGPATH}"


### PR DESCRIPTION
Allow to define move path with env var CLAMSCAN_MOVEPATH. The option is
used only when the env var is defined.