### PR TITLE
feat(ruby-webkit-headless): install libtool automake autoconf

### DIFF
--- a/ruby-webkit-headless/Dockerfile
+++ b/ruby-webkit-headless/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update -qq && apt-get install -qq -y \
   libreadline-dev libmysqlclient-dev curl \
   libcurl3 libcurl3-gnutls libcurl4-openssl-dev \
   libgconf2-4 \
-  imagemagick wget unzip
+  imagemagick wget unzip \
+  libtool automake autoconf
 
 ENV CHROMEDRIVER_DIR="/usr/local/bin/" \
   CHROMEDRIVER_VERSION="2.40" \


### PR DESCRIPTION
Add libtool, automake and autoconf in order to install gem snappy for compress/uncompress kafka message.