### PR TITLE
Feature/phony targets

### DIFF
--- a/pickle/Makefile
+++ b/pickle/Makefile
@@ -1,5 +1,5 @@
-ifndef REGISTRY
-REGISTRY := jobteaser
+ifndef DOCKER_REGISTRY
+DOCKER_REGISTRY := jobteaser
 endif
 
 ifndef VERSION
@@ -9,7 +9,7 @@ endif
 # Use this target to build the builder (default image version: alpha)
 builder:
 	@docker build                                          \
-	    -t $(REGISTRY)/coretech/pickle/builder:$(VERSION)  \
+	    -t $(DOCKER_REGISTRY)/coretech/pickle/builder:$(VERSION)  \
 	    --build-arg git_commit=$(shell git rev-parse HEAD) \
 	    --build-arg build_date=$(shell date -u +%FT%TZ)    \
 	  .

--- a/pickle/Makefile
+++ b/pickle/Makefile
@@ -13,5 +13,6 @@ builder:
 	    --build-arg git_commit=$(shell git rev-parse HEAD) \
 	    --build-arg build_date=$(shell date -u +%FT%TZ)    \
 	  .
+.PHONY: builder
 
 include build/rules.mk

--- a/pickle/build/Dockerfile
+++ b/pickle/build/Dockerfile
@@ -1,6 +1,6 @@
-ARG REGISTRY=jobteaser
-ARG USE_BUILDER=alpha
-FROM ${REGISTRY}/coretech/pickle/builder:${USE_BUILDER} AS builder
+ARG DOCKER_REGISTRY=jobteaser
+ARG BUILDER_VERSION=alpha
+FROM ${DOCKER_REGISTRY}/coretech/pickle/builder:${BUILDER_VERSION} AS builder
 
 WORKDIR /src
 COPY src .

--- a/pickle/build/rules.mk
+++ b/pickle/build/rules.mk
@@ -8,13 +8,16 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 # services builds every services
 services: $(SERVICES)
+.PHONY: services
 
 # Manually trigger the proto based go generated sourcces
 proto-go-generate: ; $(MAKE) $(GENERATED_GO_FROM_PROTO)
+.PHONY: proto-go-generate
 
 # Each service foo of SERVICES can be build by calling `make foo`
 $(SERVICES): $(GENERATED_GO_FROM_PROTO)
 	@docker-compose build $(OPTS) $@
+.PHONY: $(SERVICES)
 
 # Rule for building go sources from a proto file
 %.pb.go: %.proto
@@ -24,6 +27,7 @@ $(SERVICES): $(GENERATED_GO_FROM_PROTO)
 # Triggers the unit tests (go test)
 unit-tests: $(GENERATED_GO_FROM_PROTO)
 	@go test -mod vendor ./...
+.PHONY: unit-tests
 
 # Each service foo of SERVICES have a foo-tests target that run the integration tests (Gherkin cucumber)
 $(SERVICES:%=%-tests): $(GENERATED_GO_FROM_PROTO)
@@ -38,6 +42,7 @@ $(SERVICES:%=%-tests): $(GENERATED_GO_FROM_PROTO)
 	    echo "FAILURE: $@ returned $$exit_code" ; \
 	    exit $$exit_code ;                        \
 	fi
+.PHONY: $(SERVICES:%=%-tests)
 
 # Each service foo of SERVICES have a foo-sh target that provide a shell inside the service.
 # but without the service started. Once you are inside you can eventually run it manually.
@@ -45,36 +50,47 @@ $(SERVICES:%=%-tests): $(GENERATED_GO_FROM_PROTO)
 # to reach the test's dummy servers with their service name (service name from the docker-compose file)
 $(SERVICES:%=%-sh) $(SERVICES:%=%-tests-sh): $(GENERATED_GO_FROM_PROTO)
 	@docker-compose run --rm --use-aliases $(@:%-sh=%) sh
+.PHONY: $(SERVICES:%=%-sh) $(SERVICES:%=%-tests-sh)
 
 # Each service foo of SERVICES have a foo-force-build target that trigger a no-cache docker build
 # for this service
 $(SERVICES:%=%-force-build): ; @OPTS=--no-cache $(MAKE) $(@:%-force-build=%)
+.PHONY: $(SERVICES:%=%-force-build)
 
 # Each service foo of SERVICES can be up with target foo-up
 $(SERVICES:%=%-up): ; @docker-compose up $(@:%-up=%)
+.PHONY: $(SERVICES:%=%-up)
 
 # Each service foo of SERVICES can be down with target foo-down
 $(SERVICES:%=%-down): ; @docker-compose down $(@:%-down=%)
+.PHONY: $(SERVICES:%=%-down)
 
 # Each service foo of SERVICES have a foo-push-container to send the service
 # image to its dedicated registry
 $(SERVICES:%=%-push-container): ; @docker-compose push $(@:%-push-container=%)
+.PHONY: $(SERVICES:%=%-push-container)
 
 # up is used to up all the services
 up: services ; docker-compose $@ $(SERVICES)
+.PHONY: up
 
 # down is used to down all
 down: ; docker-compose down
+.PHONY: down
 
 # Helpful: targets foo-exec-sh and foo-tests-exec-sh for each service foo of SERVICES
 # Calling those targets provides a shell inside an already running container.
 $(SERVICES:%=%-exec-sh) $(SERVICES:%=%-tests-exec-sh): ; @docker-compose exec $(@:%-exec-sh=%) sh
+.PHONY: $(SERVICES:%=%-exec-sh) $(SERVICES:%=%-tests-exec-sh)
 
 # Remove every containers
 clean-containers: ; @docker-compose rm -sf
+.PHONY: clean-containers
 
 # Remove every untracked file
 clean-workspace: ; @git clean -fdx
+.PHONY: clean-workspace
 
 # Clean everything cleanable
 clean-all: clean-containers clean-workspace
+.PHONY: clean-all


### PR DESCRIPTION
Add the phony targets to the targe .PHONY to prevent build non-execution (case actually faced here where the target has been assumed to already have been built): https://jenkins.dev.jobteaser.net/blue/rest/organizations/jenkins/pipelines/coretech/pipelines/pickle/branches/master/runs/320/nodes/50/log/?start=0