### PR TITLE
chore(buildgo): update to librdkafka

### DIFF
--- a/buildgo/Dockerfile
+++ b/buildgo/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
-ENV LIBRDKAFKA_VERSION=0.11.5
+ENV LIBRDKAFKA_VERSION=1.0.0
 
 RUN curl -Lk -o /root/librdkafka-${LIBRDKAFKA_VERSION}.tar.gz https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz && \
       tar -xzf /root/librdkafka-${LIBRDKAFKA_VERSION}.tar.gz -C /root && \


### PR DESCRIPTION
The last version of github.com/confluentinc/confluent-kafka-go requires
librdkafka 1.0.0. This version is backward compatible.