### PR TITLE
Update prototool docker image

### DIFF
--- a/prototool/Dockerfile
+++ b/prototool/Dockerfile
@@ -1,55 +1,21 @@
-FROM golang:1.11.0-alpine3.8 AS build
-
-ENV PROTOTOOL_VERSION=1.4.0
-ENV PROTOC_VERSION=3.6.1
-ENV PROTOC_GEN_GO_VERSION=1.3.1
-ENV PROTOC_GEN_GRPC_GATEWAY_VERSION=1.8.5
-
-RUN apk add --no-cache curl git libc6-compat
-
-RUN curl -sSL https://github.com/uber/prototool/releases/download/v$PROTOTOOL_VERSION/prototool-Linux-x86_64 -o /usr/local/bin/prototool && \
-  chmod +x /usr/local/bin/prototool
-
-RUN mkdir /tmp/prototool-bootstrap && \
-  echo $'protoc:\n  version:' $PROTOC_VERSION > /tmp/prototool-bootstrap/prototool.yaml && \
-  echo 'syntax = "proto3";' > /tmp/prototool-bootstrap/tmp.proto && \
-  prototool compile /tmp/prototool-bootstrap && \
-  rm -rf /tmp/prototool-bootstrap
-
-RUN go get github.com/golang/protobuf/... && \
-  cd /go/src/github.com/golang/protobuf && \
-  git checkout -b v$PROTOC_GEN_GO_VERSION && \
-  go install ./protoc-gen-go
-
-RUN go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway && \
-  cd /go/src/github.com/grpc-ecosystem/grpc-gateway && \
-  git checkout -b v$PROTOC_GEN_GRPC_GATEWAY_VERSION && \
-  go install ./protoc-gen-grpc-gateway
-
-FROM alpine:3.8
+FROM uber/prototool:1.8.0
 
 LABEL vendor="Jobteaser" \
-  com.jobteaser.version="1.0.0" \
-  com.jobteaser.release-date="2019-01-24" \
-  com.jobteaser.origin="github.com/dockerfiles/prototool" \
-  maintainer="dev@jobteaser.com"
+      maintainer="opensource@jobteaser.com"
 
-ENV GRPC_TOOLS_GEM_VERSION=1.17
+# The official prototool image does not include the annotation proto. This RUN instruction download
+# and add the annotation proto on the right place to avoid prototool configuration.
+RUN \
+  git clone --depth 1 https://github.com/grpc-ecosystem/grpc-gateway.git /tmp/annotations && \
+  mv /tmp/annotations/third_party/googleapis/google/api /usr/include/google/api && \
+  mv /tmp/annotations/third_party/googleapis/google/rpc /usr/include/google/rpc && \
+  rm -rf /tmp/annotations
 
-RUN apk add --no-cache libc6-compat git make ruby su-exec && \
-  gem install grpc-tools -v $GRPC_TOOLS_GEM_VERSION --no-ri --no-rdoc
+RUN \
+  apk add --no-cache python3 build-base gcc python3-dev && \
+  pip3 install --upgrade pip && \
+  pip3 install grpcio~=1.21.1 && \
+  pip3 install grpcio-tools~=1.21.1 && \
+  pip3 install googleapis-common-protos
 
-COPY --from=build /usr/local/bin/prototool /usr/local/bin/prototool
-COPY --from=build /go/bin/protoc-gen-go /usr/local/bin/protoc-gen-go
-COPY --from=build /go/bin/protoc-gen-grpc-gateway /usr/local/bin/protoc-gen-grpc-gateway
-
-ENV PATH /usr/local/go/bin:$PATH
-
-RUN chmod +x /usr/local/bin/prototool && \
-  chmod +x /usr/local/bin/protoc-gen-go && \
-  chmod +x /usr/local/bin/protoc-gen-grpc-gateway
-
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["prototool"]

--- a/prototool/README.md
+++ b/prototool/README.md
@@ -5,4 +5,4 @@ Prototool provides a build environment as a docker image `jobteaser/prototool`.
 This can be used for making generation of API files based on proto either on a CI machine or locally
 on a developper environment.
 
-The image also contains `make` `git` `ruby` and `go`
+This image can build proto and gRPC for `ruby`, `go` and `python3`.


### PR DESCRIPTION
* Use official uber prototool image
* Add support of google.http.api proto option
* Add support for python3 (proto and gRPC)