### PR TITLE
feat(erlang): add a ci image

### DIFF
--- a/erlang/Dockerfile
+++ b/erlang/Dockerfile
@@ -1,0 +1,13 @@
+
+# Arguments
+ARG erlang_version="22"
+
+# Build
+FROM erlang:${erlang_version}
+
+LABEL vendor="JobTeaser"
+LABEL maintainer="opensource@jobteaser.com"
+
+RUN apt-get update
+RUN apt-get install -y clang libicu-dev
+RUN apt-get purge -y


### PR DESCRIPTION
We need everything used in our erlang libraries, starting with libicu.