### PR TITLE
Enable providing package versions at build time

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine
 
-ARG CURATOR_VERSION=5.6.0
-ARG PYYAML_VERSION=3.12
-
 LABEL vendor="JobTeaser" \
       com.jobteaser.version="1.0.1" \
-      com.jobteaser.release-date="2018-09-17" \
+      com.jobteaser.release-date="2019-10-10" \
       maintainer="dev@jobteaser.com"
+
+ARG CURATOR_VERSION=5.6.0
+ARG PYYAML_VERSION=3.12
 
 RUN apk --no-cache add python3 py3-pip && \
     pip3 install --upgrade pip && \

--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine
 
+ARG CURATOR_VERSION=5.6.0
+ARG PYYAML_VERSION=3.12
+
 LABEL vendor="JobTeaser" \
       com.jobteaser.version="1.0.1" \
       com.jobteaser.release-date="2018-09-17" \
       maintainer="dev@jobteaser.com"
-
-ENV CURATOR_VERSION 5.6.0
-ENV PYYAML_VERSION 3.12
 
 RUN apk --no-cache add python3 py3-pip && \
     pip3 install --upgrade pip && \


### PR DESCRIPTION
The latest version (5.6.0) is incompatible with ES 7.3.0, and we were unable to find a built image with a more recent version. That led us to cook our own image, using the modified Dockerfile in this PR.

I'm submitting this for your consideration, just in case you find the enhancement useful.