### PR TITLE
feat(dnsmask): Create image for dnsmask

### DIFF
--- a/dnsmasq/Dockerfile
+++ b/dnsmasq/Dockerfile
@@ -1,0 +1,23 @@
+# Courtesy of https://github.com/gearnode/dnsmasq
+FROM ubuntu:20.04 AS builder
+
+ARG DNSMASQ_REPOSITORY=http://thekelleys.org.uk/git/dnsmasq.git
+ARG VERSION=2.82
+
+RUN apt-get update && \
+  apt-get install -y make git gcc && \
+  git clone ${DNSMASQ_REPOSITORY} /tmp/dnsmasq && \
+  cd /tmp/dnsmasq && \
+  git checkout -b ${VERSION} && \
+  make install
+
+FROM ubuntu:20.04
+
+LABEL version=${VERSION} \
+  maintainer=squad-devex@jobteaser.com
+
+COPY --from=builder /usr/local/sbin/dnsmasq /usr/local/sbin/dnsmasq
+
+EXPOSE 53 53/udp
+
+ENTRYPOINT ["dnsmasq", "-k"]


### PR DESCRIPTION
We need to use `dnsmasq` for the `apigw` proxy and right now the image we use is one from Bryan personal github account:
- https://github.com/gearnode/dnsmasq

While the image can still be public, it is better to keep the `Dockerfile` and the process to build the image, inside Jobteaser organisation.

This `Dockerfile` is the same as https://github.com/gearnode/dnsmasq and I only updated:
- version of ubuntu
- fixed version of `dnsmasq`
- email for maintainer

Repository created on dockerhub (public): https://hub.docker.com/repository/docker/jobteaser/dnsmasq