### PR TITLE
Elixir 1.10.4 otp23.1 npm 6

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -4,9 +4,9 @@ LABEL vendor="JobTeaser"
 LABEL maintainer="opensource@jobteaser.com"
 
 # Erlang Solutions build
-ENV ERLANG_VERSION 21.3.8.6
+ENV ERLANG_VERSION 23.1
 
-ENV ELIXIR_VERSION 1.8.2
+ENV ELIXIR_VERSION 1.10.4
 ENV NODE_VERSION 9.7.0
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="opensource@jobteaser.com"
 ENV ERLANG_VERSION 23.1
 
 ENV ELIXIR_VERSION 1.10.4
-ENV NODE_VERSION 9.7.0
+ENV NODE_VERSION 14.15.4
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Use elixir 1.10.4
Use npm 6.11.4 instead of npm 5, which comes with nodejs 9.7