### PR TITLE
chore(diagnostic) add redis-cli

### DIFF
--- a/diagnostic/Dockerfile
+++ b/diagnostic/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y && \
       socat \
       traceroute \
       wget \
+      redis-server \
     && \
     ( \
       cd /tmp && \


### PR DESCRIPTION
This PR contains:
* Add redis-cli in diagnostic dockerfile.

