### PR TITLE
chore(diagnostic): Upgrade the diagnostic image to ubuntu latest LTS

### DIFF
--- a/diagnostic/Dockerfile
+++ b/diagnostic/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL vendor="Jobteaser"
 LABEL maintainer="foundation@jobteaser.com"


### PR DESCRIPTION
The `postgresql-client` version is not sync anymore with the version
in production for our micro-services.
It results in the following error when trying to describe a table:

```
=> \d users
ERROR:  column c.relhasoids does not exist
LINE 1: ...riggers, c.relrowsecurity, c.relforcerowsecurity, c.relhasoi...
```

This commit upgrades the ubuntu version to get the latest postgresql
version (12.9) and hopefully will fix the issue.

https://jobteaser.slack.com/archives/C9GLT2TRD/p1640703757179900