### PR TITLE
chore(phraseapp): add curl to use image for autocreate/merge phraseapp PRs

### DIFF
--- a/phraseapp/Dockerfile
+++ b/phraseapp/Dockerfile
@@ -12,6 +12,7 @@ ENV NODE_VERSION 16.10.0
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+        curl \
         ca-certificates \
         wget \
         git \


### PR DESCRIPTION
## Description

The present PR add `curl` to the `phraseapp` image in order to use it during the `autocreate-phraseapp-pr` & `automerge-pr` in js-jobteaser repository (reqiures `curl` to interact with github API).