### PR TITLE
chore(elixir): upgrade Elixir to 1.14.3 and Erlang to 25.3

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -4,9 +4,9 @@ LABEL vendor="JobTeaser"
 LABEL maintainer="opensource@jobteaser.com"
 
 # Erlang Solutions build
-ENV ERLANG_VERSION 23.2.3
+ENV ERLANG_VERSION 25.3
 
-ENV ELIXIR_VERSION 1.13.3
+ENV ELIXIR_VERSION 1.14.3
 ENV NODE_VERSION 14.15.4
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Upgrade Elixir and Erlang to their latest versions according to https://www.notion.so/Elixir-Erlang-and-Node-js-upgrades-6de8fd346d5c47c3bf964fcc3f259f6e?pvs=4

Image on DockerHub [here](https://hub.docker.com/layers/jobteaser/elixir/1.14.3-otp-25.3/images/sha256-4aa9d744ec30f89380beee1517041c4442d7b999a9972ba5307cfc15412afe35)