### PR TITLE
Install  `postgresql-client` in elixir container

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG C.UTF-8
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev && \
+      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev postgresql-client && \
     ( \
       cd /tmp && \
       wget -q https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz && \


### PR DESCRIPTION
We need the `postgresql-client` package because it provides access to the `psql` utility which we need at test time.