### PR TITLE
chore(elixir): upgrade Elixir to 1.16.1 and Erlang to 26.2.1

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -4,9 +4,9 @@ LABEL vendor="JobTeaser"
 LABEL maintainer="opensource@jobteaser.com"
 
 # Erlang Solutions build
-ENV ERLANG_VERSION 26.1.2
+ENV ERLANG_VERSION 26.2.1
 
-ENV ELIXIR_VERSION 1.16.0
+ENV ELIXIR_VERSION 1.16.1
 ENV NODE_VERSION 18.12.0
 
 ENV UBUNTU_VERSION focal

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG C.UTF-8
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev postgresql-client && \
+      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev && \
     ( \
       cd /tmp && \
       wget -q https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz && \

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG C.UTF-8
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev && \
+      bash wget ca-certificates unzip git openssh-client docker.io make clang libicu-dev postgresql-client && \
     ( \
       cd /tmp && \
       wget -q https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz && \


### PR DESCRIPTION
Upgrade Erlang end Elixir versions.
~Additionally, we also install the `postgresql-client` package: it provides access to the `psql` utility which we will need at test time.~ We do not want debugging tools like `psql` in production containers for security reasons.